### PR TITLE
Added "Randomize color" option to Box tool

### DIFF
--- a/tools/box/src/main.lua
+++ b/tools/box/src/main.lua
@@ -30,11 +30,15 @@ function on_pointer_down(point)
     prev_fixed_pointer_pos = self:pointer_pos();
     print("Pointer down at " .. point.x .. ", " .. point.y);
     start = point;
-    -- random rgb color
-    local r = math.random(0x50, 0xff);
-    local g = math.random(0x50, 0xff);
-    local b = math.random(0x50, 0xff);
-    box_color = Color:rgb(r / 0xff, g / 0xff, b / 0xff);
+    if self:get_property("randomize_colors").value then
+        -- random rgb color
+        local r = math.random(0x50, 0xff);
+        local g = math.random(0x50, 0xff);
+        local b = math.random(0x50, 0xff);
+        box_color = Color:rgb(r / 0xff, g / 0xff, b / 0xff);
+    else
+        box_color = Color:hex(0xe2d3b8);
+    end;
 
     if overlay == nil then
         overlay = Overlays:add();

--- a/tools/box/tool.toml
+++ b/tools/box/tool.toml
@@ -5,6 +5,16 @@ script = "./src/main.lua"
 icon = "./icon.png"
 
 [[property]]
+id = "randomize_colors"
+
+name = "Randomize colors"
+tooltip = "Make boxes colorful instead of giving them all the same drab beige"
+
+input_type = "toggle"
+
+default_value = true
+
+[[property]]
 id = "uranium"
 
 name = "Put uranium in the box"


### PR DESCRIPTION
Test PR just to make sure everything's working (and also cause i just ran out of time)

Now my builds won't be vibrant rainbows! hooray

option is on by default

![image](https://github.com/user-attachments/assets/d02466cb-bc72-40d5-bac8-c483815a8087)
